### PR TITLE
Make tests work for app-spec-rust

### DIFF
--- a/bindings/app.cpp
+++ b/bindings/app.cpp
@@ -21,6 +21,20 @@ App::App(QString hash, QObject *parent) : QObject(parent), m_hash(hash)
     }
 }
 
+
+App::App(Dna *dna, QObject *parent) : QObject(parent)
+{
+    m_dna = dna;
+    if(m_dna){
+        // need to clone a dna object because holochain_new() consumes it..
+        // Might wanna change that on the rust side?
+        Dna *dna_clone = holochain_dna_create_from_json(holochain_dna_to_json(m_dna));
+        m_instance = holochain_new(dna_clone);
+    } else {
+        m_instance = 0;
+    }
+}
+
 void App::start(){
     if(m_instance) {
         holochain_start(m_instance);

--- a/bindings/app.h
+++ b/bindings/app.h
@@ -23,6 +23,7 @@ class App : public QObject
 public:
     App();
     explicit App(QString hash, QObject *parent = nullptr);
+    explicit App(Dna* dna, QObject *parent = nullptr);
     Q_INVOKABLE void start();
     Q_INVOKABLE void stop();
     Q_INVOKABLE QString call(QString zome, QString capability, QString function, QString parameters);

--- a/bindings/container.h
+++ b/bindings/container.h
@@ -16,6 +16,7 @@ public:
     Q_INVOKABLE QString appName(QString app_hash);
     Q_INVOKABLE QList<App*> instances();
     Q_INVOKABLE App* instantiate(QString app_hash);
+    Q_INVOKABLE App* loadAndInstantiate(QString path);
 
 signals:
     void appsChanged();

--- a/holoconsole/holoconsole.pro
+++ b/holoconsole/holoconsole.pro
@@ -1,6 +1,8 @@
 QT += qml concurrent
 CONFIG += c++11
 CONFIG -= qtquickcompiler
+CONFIG += console
+CONFIG -= app_bundle
 
 # The following define makes your compiler emit warnings if you use
 # any feature of Qt which as been marked deprecated (the exact warnings


### PR DESCRIPTION
So far, HoloSqape and thus also holoconsole were managing a list of installed apps and instantiating only from there. For tests we don't want that and instead have holoconsole read and instantiate a DNA file on the fly. The added function `Container.loadAndInstantiate(filepath)` does that.

Also had to add error output for exceptions thrown in callbacks, like in tape, so that it does not fail silently.