### PR TITLE
Pass storage path to core_api

### DIFF
--- a/bindings/app.cpp
+++ b/bindings/app.cpp
@@ -116,7 +116,15 @@ App* App::load(QString hash, QString storage_path) {
     Dna *dna = getDna(hash);
     if(!dna) return 0;
     App *app = new App;
+    //
+    // TODO: Use holochain_load
+    //
+    // This should be:
+    // app->m_instance = holochain_load(storage_path.toStdString().c_str());
+    // But holochain_load is not implemented on Rust side yet.
+    // Replace this line as soon as it is.
     app->m_instance = holochain_new(dna, storage_path.toStdString().c_str());
+
     // need to recreate a dna object because holochain_new() consumes it..
     // Might wanna change that on the rust side?
     app->m_dna = getDna(hash);

--- a/bindings/app.h
+++ b/bindings/app.h
@@ -22,8 +22,8 @@ class App : public QObject
     Q_OBJECT
 public:
     App();
-    explicit App(QString hash, QObject *parent = nullptr);
-    explicit App(Dna* dna, QObject *parent = nullptr);
+    explicit App(QString hash, QString storage_path, QObject *parent = nullptr);
+    explicit App(Dna* dna, QString storage_path, QObject *parent = nullptr);
     Q_INVOKABLE void start();
     Q_INVOKABLE void stop();
     Q_INVOKABLE QString call(QString zome, QString capability, QString function, QString parameters);
@@ -33,6 +33,7 @@ public:
     Q_INVOKABLE QStringList parameter_names(QString zome, QString capability, QString function);
     Q_INVOKABLE QString hash() const;
     Q_INVOKABLE QString name() const;
+    static App* load(QString hash, QString storage_path);
 
 signals:
 

--- a/bindings/container.h
+++ b/bindings/container.h
@@ -23,7 +23,9 @@ public:
     Q_INVOKABLE App* instantiate(QString app_hash);
     Q_INVOKABLE App* loadAndInstantiate(QString path);
     Q_INVOKABLE QString rootUIsDirectoryPath();
+    Q_INVOKABLE QString instancesDirectoryPath();
     QDir rootUIsDirectory();
+    QDir instancesDirectory();
 
 
 signals:


### PR DESCRIPTION
Related to https://github.com/holochain/holochain-rust/issues/518
Dependent on https://github.com/holochain/holochain-rust/pull/519

Needed changes after changing the core_api function signatures to expect a storage path argument.

HoloSqape (and hcshelll) manage a `instances` directory next to the rootUIs where each installed app holds their storage. Passes path over to core.

A consequence is that HoloSqape knows if the app was there before, just because the directory exists already. If that is the case, it calls `App::load(String path)` instead of `new App(dna, path)`. Currently `App::load()` also calls `holochain_new` because `holochain_load` is not implemented yet. Should be changed soon after.